### PR TITLE
feat: persist foods with localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Ernährungstracker</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Ernährungstracker</h1>
+    <form id="food-form">
+        <input type="text" id="food-name" placeholder="Food" required>
+        <input type="number" id="food-calories" placeholder="Calories" required>
+        <button type="submit">Add</button>
+    </form>
+    <button id="reset-btn">Reset</button>
+    <table id="food-table">
+        <thead>
+            <tr>
+                <th>Food</th>
+                <th>Calories</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <div id="total">Total Calories: <span id="total-calories">0</span></div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,72 @@
+let foods = [];
+
+function saveFoods() {
+    localStorage.setItem('foods', JSON.stringify(foods));
+}
+
+function renderFoods() {
+    const tbody = document.querySelector('#food-table tbody');
+    tbody.innerHTML = '';
+    foods.forEach((food, index) => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <td>${food.name}</td>
+            <td>${food.calories}</td>
+            <td>
+                <button class="edit" data-index="${index}">Edit</button>
+                <button class="delete" data-index="${index}">Delete</button>
+            </td>
+        `;
+        tbody.appendChild(row);
+    });
+    const total = foods.reduce((sum, f) => sum + Number(f.calories), 0);
+    document.getElementById('total-calories').textContent = total;
+}
+
+function loadFoods() {
+    const stored = localStorage.getItem('foods');
+    if (stored) {
+        foods = JSON.parse(stored);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadFoods();
+    renderFoods();
+
+    document.getElementById('food-form').addEventListener('submit', e => {
+        e.preventDefault();
+        const name = document.getElementById('food-name').value.trim();
+        const calories = parseInt(document.getElementById('food-calories').value, 10);
+        if (!name) return;
+        foods.push({ name, calories });
+        saveFoods();
+        renderFoods();
+        e.target.reset();
+    });
+
+    document.getElementById('food-table').addEventListener('click', e => {
+        if (e.target.classList.contains('edit')) {
+            const idx = e.target.dataset.index;
+            const food = foods[idx];
+            const newName = prompt('Food name', food.name);
+            const newCal = prompt('Calories', food.calories);
+            if (newName !== null && newCal !== null) {
+                foods[idx] = { name: newName.trim(), calories: parseInt(newCal, 10) };
+                saveFoods();
+                renderFoods();
+            }
+        } else if (e.target.classList.contains('delete')) {
+            const idx = e.target.dataset.index;
+            foods.splice(idx, 1);
+            saveFoods();
+            renderFoods();
+        }
+    });
+
+    document.getElementById('reset-btn').addEventListener('click', () => {
+        foods = [];
+        localStorage.removeItem('foods');
+        renderFoods();
+    });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,19 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-top: 10px;
+}
+
+th, td {
+    border: 1px solid #ddd;
+    padding: 8px;
+}
+
+th {
+    background: #f4f4f4;
+}


### PR DESCRIPTION
## Summary
- persist added foods to `localStorage` and restore them on load
- render totals and allow editing/deleting while keeping storage in sync
- add reset button to clear food list and storage

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9724c4b34832b920f03b442bd2bcb