### PR TITLE
Persist nutrition entries with localStorage

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,10 +1,32 @@
-const foodList = [];
-const totals = {
+const foodList = JSON.parse(localStorage.getItem('foodList')) || [];
+const totals = JSON.parse(localStorage.getItem('totals')) || {
     calories: 0,
     protein: 0,
     carbs: 0,
     fat: 0
 };
+
+function renderData() {
+    const tbody = document.querySelector('#foods-table tbody');
+    tbody.innerHTML = '';
+    foodList.forEach(({ name, calories, protein, carbs, fat }) => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <td>${name}</td>
+            <td>${calories}</td>
+            <td>${protein}</td>
+            <td>${carbs}</td>
+            <td>${fat}</td>
+        `;
+        tbody.appendChild(row);
+    });
+    document.getElementById('total-calories').textContent = totals.calories;
+    document.getElementById('total-protein').textContent = totals.protein;
+    document.getElementById('total-carbs').textContent = totals.carbs;
+    document.getElementById('total-fat').textContent = totals.fat;
+}
+
+renderData();
 
 document.getElementById('food-form').addEventListener('submit', function(event) {
     event.preventDefault();
@@ -23,26 +45,15 @@ document.getElementById('food-form').addEventListener('submit', function(event) 
     const food = { name, calories, protein, carbs, fat };
     foodList.push(food);
 
-    const tbody = document.querySelector('#foods-table tbody');
-    const row = document.createElement('tr');
-    row.innerHTML = `
-        <td>${name}</td>
-        <td>${calories}</td>
-        <td>${protein}</td>
-        <td>${carbs}</td>
-        <td>${fat}</td>
-    `;
-    tbody.appendChild(row);
-
     totals.calories += calories;
     totals.protein += protein;
     totals.carbs += carbs;
     totals.fat += fat;
 
-    document.getElementById('total-calories').textContent = totals.calories;
-    document.getElementById('total-protein').textContent = totals.protein;
-    document.getElementById('total-carbs').textContent = totals.carbs;
-    document.getElementById('total-fat').textContent = totals.fat;
+    localStorage.setItem('foodList', JSON.stringify(foodList));
+    localStorage.setItem('totals', JSON.stringify(totals));
+
+    renderData();
 
     event.target.reset();
 });


### PR DESCRIPTION
## Summary
- Store food entries and totals in localStorage
- Load stored entries on startup and render table and totals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b976c5485c832b8727d412fbb8ff0b